### PR TITLE
fix: include symlinks in checks

### DIFF
--- a/src/check_sdist/sdist.py
+++ b/src/check_sdist/sdist.py
@@ -24,7 +24,9 @@ def sdist_files(source_dir: Path, isolated: bool) -> frozenset[str]:
                 msg = f"malformted SDist, contains multiple packages {prefixes}"
                 raise AssertionError(msg)
             return frozenset(
-                t.name.split("/", maxsplit=1)[1] for t in tar.getmembers() if t.isfile()
+                t.name.split("/", maxsplit=1)[1]
+                for t in tar.getmembers()
+                if t.isfile() or t.issym()
             )
 
 

--- a/tests/downstream.toml
+++ b/tests/downstream.toml
@@ -18,6 +18,10 @@ repo = "scikit-build/scikit-build-core"
 ref = "v0.2.1"
 
 [[packages]]
+repo = "scikit-build/scikit-build"
+ref = "0.17.0"
+
+[[packages]]
 repo = "pybind/pybind11"
 ref = "v2.10.3"
 fail = 2


### PR DESCRIPTION
This was missing symlinks (regression in 0.1.1).
