### PR TITLE
Add possibility to check with flit build

### DIFF
--- a/src/check_sdist/__main__.py
+++ b/src/check_sdist/__main__.py
@@ -15,7 +15,9 @@ from .resources import resources
 from .sdist import sdist_files
 
 
-def compare(source_dir: Path, *, isolated: bool, verbose: bool = False, buildsystem: str) -> int:
+def compare(
+    source_dir: Path, *, isolated: bool, verbose: bool = False, buildsystem: str
+) -> int:
     """
     Compare the files in the SDist with the files tracked by git.
 
@@ -113,7 +115,12 @@ def main(sys_args: Sequence[str] | None = None, /) -> None:
             stack.enter_context(inject_junk_files(args.source_dir))
 
     raise SystemExit(
-        compare(args.source_dir, isolated=not args.no_isolation, verbose=args.verbose, buildsystem=args.buildsystem)
+        compare(
+            args.source_dir,
+            isolated=not args.no_isolation,
+            verbose=args.verbose,
+            buildsystem=args.buildsystem,
+        )
     )
 
 

--- a/src/check_sdist/__main__.py
+++ b/src/check_sdist/__main__.py
@@ -15,7 +15,7 @@ from .resources import resources
 from .sdist import sdist_files
 
 
-def compare(source_dir: Path, *, isolated: bool, verbose: bool = False) -> int:
+def compare(source_dir: Path, *, isolated: bool, verbose: bool = False, buildsystem: str) -> int:
     """
     Compare the files in the SDist with the files tracked by git.
 
@@ -27,7 +27,7 @@ def compare(source_dir: Path, *, isolated: bool, verbose: bool = False) -> int:
     conditions are true.
     """
 
-    sdist = sdist_files(source_dir, isolated) - {"PKG-INFO"}
+    sdist = sdist_files(source_dir, isolated, buildsystem) - {"PKG-INFO"}
     git = git_files(source_dir)
 
     config = {}
@@ -99,6 +99,13 @@ def main(sys_args: Sequence[str] | None = None, /) -> None:
         action="store_true",
         help="Print out SDist contents too",
     )
+    parser.add_argument(
+        "-b",
+        "--buildsystem",
+        type=str,
+        default="build",
+        help="Build system to build SDist.",
+    )
     args = parser.parse_args(sys_args)
 
     with contextlib.ExitStack() as stack:
@@ -106,7 +113,7 @@ def main(sys_args: Sequence[str] | None = None, /) -> None:
             stack.enter_context(inject_junk_files(args.source_dir))
 
     raise SystemExit(
-        compare(args.source_dir, isolated=not args.no_isolation, verbose=args.verbose)
+        compare(args.source_dir, isolated=not args.no_isolation, verbose=args.verbose, buildsystem=args.buildsystem)
     )
 
 

--- a/src/check_sdist/sdist.py
+++ b/src/check_sdist/sdist.py
@@ -25,6 +25,7 @@ def _sdist_files_build(source_dir: Path, isolated: bool):
         cmd = [sys.executable, "-m", "build", "--sdist", "--outdir", outdir]
         return _run(source_dir, isolated, cmd, outdir)
 
+
 def _sdist_files_flit(source_dir: Path, isolated: bool):
     """Create subprocess command for flit."""
     cmd = [sys.executable, "-m", "flit", "build"]

--- a/src/check_sdist/sdist.py
+++ b/src/check_sdist/sdist.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import tarfile
@@ -7,27 +8,54 @@ import tempfile
 from pathlib import Path
 
 
-def sdist_files(source_dir: Path, isolated: bool) -> frozenset[str]:
+def sdist_files(source_dir: Path, isolated: bool, buildsystem: str) -> frozenset[str]:
     """Return the files that would be (are) placed in the SDist."""
+    if buildsystem not in BUILD_SYSTEMS:
+        msg = (
+            f"No check for build system '{buildsystem}' implemented. Available "
+            "systems are: '" + "', '".join(BUILD_SYSTEMS) + "'."
+        )
+        raise NotImplementedError(msg)
+    return BUILD_SYSTEMS[buildsystem](source_dir, isolated)
 
+
+def _sdist_files_build(source_dir: Path, isolated: bool):
+    """Create subprocess command for build."""
     with tempfile.TemporaryDirectory() as outdir:
         cmd = [sys.executable, "-m", "build", "--sdist", "--outdir", outdir]
-        if not isolated:
-            cmd.append("--no-isolation")
-        subprocess.run(cmd, check=True, cwd=source_dir)
+        return _run(source_dir, isolated, cmd, outdir)
 
-        (outpath,) = Path(outdir).glob("*.tar.gz")
+def _sdist_files_flit(source_dir: Path, isolated: bool):
+    """Create subprocess command for flit."""
+    cmd = [sys.executable, "-m", "flit", "build"]
+    outdir = os.path.join(source_dir, "dist")
+    return _run(source_dir, isolated, cmd, outdir)
 
-        with tarfile.open(outpath) as tar:
-            prefixes = {n.split("/", maxsplit=1)[0] for n in tar.getnames()}
-            if len(prefixes) != 1:
-                msg = f"malformted SDist, contains multiple packages {prefixes}"
-                raise AssertionError(msg)
-            return frozenset(
-                t.name.split("/", maxsplit=1)[1]
-                for t in tar.getmembers()
-                if t.isfile() or t.issym()
-            )
+
+def _run(source_dir: Path, isolated: bool, cmd: list, outdir: str):
+    """Run build command and return file list."""
+    if not isolated:
+        cmd.append("--no-isolation")
+    subprocess.run(cmd, check=True, cwd=source_dir)
+
+    (outpath,) = Path(outdir).glob("*.tar.gz")
+
+    with tarfile.open(outpath) as tar:
+        prefixes = {n.split("/", maxsplit=1)[0] for n in tar.getnames()}
+        if len(prefixes) != 1:
+            msg = f"malformted SDist, contains multiple packages {prefixes}"
+            raise AssertionError(msg)
+        return frozenset(
+            t.name.split("/", maxsplit=1)[1]
+            for t in tar.getmembers()
+            if t.isfile() or t.issym()
+        )
+
+
+BUILD_SYSTEMS = {
+    "build": _sdist_files_build,
+    "flit": _sdist_files_flit,
+}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See #15 

This implements different functions to check the sdist for different builds. For now only `flit` and `build`, where `build` is the default to retain the original behavior of the tool. The structure should make it rather easy to implement other build systems as well. Also, an error message is provided to the user, in case a non-supported buildsystem is chosen indicating, which build systems are supported.