### PR TITLE
fix: also check for .egg-info inside tests folder

### DIFF
--- a/src/check_sdist/resources/junk-paths.txt
+++ b/src/check_sdist/resources/junk-paths.txt
@@ -7,6 +7,7 @@
 dist/
 tests/__pycache__/
 tests/any/__pycache__/
+tests/package/anything.egg-info/
 anything.egg-info/
 __pycache__/
 .DS_Store


### PR DESCRIPTION
Noticed with build, https://github.com/pypa/build/pull/661. Adding `/tests` could cause this to slip in if you have example packages (rare).