### PR TITLE
feat: add recurse-submodules option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ recurse-submodules = true
 You can add `.gitignore` style lines here, and you can turn off the default
 ignore list, which adds some default git-only files.
 
+By default, check-sdist recursively scans the contents of Git submodules, but
+you can disable this behavior (e.g. to support older Git versions that don't
+have this capability).
+
 ### See also
 
 - [check-manifest](https://github.com/mgedmin/check-manifest): A (currently)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ To configure, these options are supported in your `pyproject.toml` file:
 sdist-only = []
 git-only = []
 default-ignore = true
+recurse-submodules = true
 ```
 
 You can add `.gitignore` style lines here, and you can turn off the default

--- a/src/check_sdist/__main__.py
+++ b/src/check_sdist/__main__.py
@@ -20,7 +20,7 @@ def compare(
     *,
     isolated: bool,
     verbose: bool = False,
-    recurse_submodules: bool = False,
+    recurse_submodules: bool = True,
 ) -> int:
     """
     Compare the files in the SDist with the files tracked by git.
@@ -106,9 +106,9 @@ def main(sys_args: Sequence[str] | None = None, /) -> None:
         help="Print out SDist contents too",
     )
     parser.add_argument(
-        "--recurse-submodules",
+        "--no-recurse-submodules",
         action="store_true",
-        help="Recursively check the contents of Git submodules",
+        help="Do not recursively check the contents of Git submodules",
     )
     args = parser.parse_args(sys_args)
 
@@ -121,7 +121,7 @@ def main(sys_args: Sequence[str] | None = None, /) -> None:
             args.source_dir,
             isolated=not args.no_isolation,
             verbose=args.verbose,
-            recurse_submodules=args.recurse_submodules,
+            recurse_submodules=not args.no_recurse_submodules,
         )
     )
 

--- a/src/check_sdist/__main__.py
+++ b/src/check_sdist/__main__.py
@@ -15,7 +15,13 @@ from .resources import resources
 from .sdist import sdist_files
 
 
-def compare(source_dir: Path, *, isolated: bool, verbose: bool = False) -> int:
+def compare(
+    source_dir: Path,
+    *,
+    isolated: bool,
+    verbose: bool = False,
+    recurse_submodules: bool = False,
+) -> int:
     """
     Compare the files in the SDist with the files tracked by git.
 
@@ -28,7 +34,7 @@ def compare(source_dir: Path, *, isolated: bool, verbose: bool = False) -> int:
     """
 
     sdist = sdist_files(source_dir, isolated) - {"PKG-INFO"}
-    git = git_files(source_dir)
+    git = git_files(source_dir, recurse_submodules=recurse_submodules)
 
     config = {}
     pyproject_toml = source_dir.joinpath("pyproject.toml")
@@ -99,6 +105,11 @@ def main(sys_args: Sequence[str] | None = None, /) -> None:
         action="store_true",
         help="Print out SDist contents too",
     )
+    parser.add_argument(
+        "--recurse-submodules",
+        action="store_true",
+        help="Recursively check the contents of Git submodules",
+    )
     args = parser.parse_args(sys_args)
 
     with contextlib.ExitStack() as stack:
@@ -106,7 +117,12 @@ def main(sys_args: Sequence[str] | None = None, /) -> None:
             stack.enter_context(inject_junk_files(args.source_dir))
 
     raise SystemExit(
-        compare(args.source_dir, isolated=not args.no_isolation, verbose=args.verbose)
+        compare(
+            args.source_dir,
+            isolated=not args.no_isolation,
+            verbose=args.verbose,
+            recurse_submodules=args.recurse_submodules,
+        )
     )
 
 

--- a/src/check_sdist/__main__.py
+++ b/src/check_sdist/__main__.py
@@ -15,12 +15,7 @@ from .resources import resources
 from .sdist import sdist_files
 
 
-def compare(
-    source_dir: Path,
-    *,
-    isolated: bool,
-    verbose: bool = False,
-) -> int:
+def compare(source_dir: Path, *, isolated: bool, verbose: bool = False) -> int:
     """
     Compare the files in the SDist with the files tracked by git.
 
@@ -112,11 +107,7 @@ def main(sys_args: Sequence[str] | None = None, /) -> None:
             stack.enter_context(inject_junk_files(args.source_dir))
 
     raise SystemExit(
-        compare(
-            args.source_dir,
-            isolated=not args.no_isolation,
-            verbose=args.verbose,
-        )
+        compare(args.source_dir, isolated=not args.no_isolation, verbose=args.verbose)
     )
 
 

--- a/src/check_sdist/git.py
+++ b/src/check_sdist/git.py
@@ -4,10 +4,12 @@ import subprocess
 from pathlib import Path
 
 
-def git_files(source_dir: Path) -> frozenset[str]:
+def git_files(source_dir: Path, recurse_submodules: bool = False) -> frozenset[str]:
     """Return the files that are tracked by git in the source directory."""
 
     cmd = ["git", "ls-files", "--cached"]
+    if recurse_submodules:
+        cmd.append("--recurse-submodules")
     return frozenset(
         subprocess.run(
             cmd,

--- a/src/check_sdist/git.py
+++ b/src/check_sdist/git.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 
 
-def git_files(source_dir: Path, recurse_submodules: bool = False) -> frozenset[str]:
+def git_files(source_dir: Path, recurse_submodules: bool = True) -> frozenset[str]:
     """Return the files that are tracked by git in the source directory."""
 
     cmd = ["git", "ls-files", "--cached"]

--- a/tests/downstream.toml
+++ b/tests/downstream.toml
@@ -25,3 +25,7 @@ ref = "0.17.0"
 repo = "pybind/pybind11"
 ref = "v2.10.3"
 fail = 2
+
+[[packages]]
+repo = "isce-framework/snaphu-py"
+ref = "v0.3.0"

--- a/tests/test_downstream.py
+++ b/tests/test_downstream.py
@@ -19,28 +19,14 @@ with DIR.joinpath("downstream.toml").open("rb") as f:
 )
 def test_packages(repo, ref, fail, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    subprocess.run(
-        ["git", "clone", f"https://github.com/{repo}", "--branch", ref], check=True
-    )
+    cmd = [
+        "git",
+        "clone",
+        f"https://github.com/{repo}",
+        "--branch",
+        ref,
+        "--recurse-submodules",
+    ]
+    subprocess.run(cmd, check=True)
     package_path = tmp_path / repo.split("/")[1]
     assert compare(package_path, isolated=True) == fail
-
-
-def test_submodules(tmp_path, monkeypatch):
-    repo = "isce-framework/snaphu-py"
-    ref = "v0.2.0"
-    monkeypatch.chdir(tmp_path)
-    subprocess.run(
-        [
-            "git",
-            "clone",
-            f"https://github.com/{repo}",
-            "--branch",
-            ref,
-            "--recurse-submodules",
-        ],
-        check=True,
-    )
-    package_path = tmp_path / repo.split("/")[1]
-    assert compare(package_path, isolated=True, recurse_submodules=False) == 2
-    assert compare(package_path, isolated=True, recurse_submodules=True) == 0

--- a/tests/test_downstream.py
+++ b/tests/test_downstream.py
@@ -24,3 +24,23 @@ def test_packages(repo, ref, fail, tmp_path, monkeypatch):
     )
     package_path = tmp_path / repo.split("/")[1]
     assert compare(package_path, isolated=True) == fail
+
+
+def test_submodules(tmp_path, monkeypatch):
+    repo = "isce-framework/snaphu-py"
+    ref = "v0.2.0"
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            f"https://github.com/{repo}",
+            "--branch",
+            ref,
+            "--recurse-submodules",
+        ],
+        check=True,
+    )
+    package_path = tmp_path / repo.split("/")[1]
+    assert compare(package_path, isolated=True, recurse_submodules=False) == 2
+    assert compare(package_path, isolated=True, recurse_submodules=True) == 0


### PR DESCRIPTION
Closes #34

Adds a command line option `--recurse-submodules` that passes the [corresponding flag](https://git-scm.com/docs/git-ls-files#Documentation/git-ls-files.txt---recurse-submodules) to the `git ls-files` command. The option is disabled by default.

I found it surprisingly tricky to find an example repo to use in a unit test that includes submodules and has no inconsistencies between the sdist contents vs files tracked by Git. (I gave it a try with nanobind and a few of the scikit-hep repos, among others.) Eventually, I gave up and used my own repo, but am very happy to replace this with a more prominent exemplar, if we can find one.