### PR TITLE
feat: add --installer option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - uses: yezz123/setup-uv@v4
+
       - name: Install package
-        run: python -m pip install .[test]
+        run: uv pip install -e.[test] --system
 
       - name: Test package
-        run: python -m pytest -ra --cov=check-sdist
+        run: pytest -ra --cov=check-sdist
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,6 @@ ci:
   autofix_commit_msg: "style: pre-commit fixes"
 
 repos:
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: "24.4.0"
-    hooks:
-      - id: black-jupyter
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v4.6.0"
     hooks:
@@ -43,6 +38,7 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.9.0"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,6 +7,7 @@
   pass_filenames: false
   always_run: true
   args: [--inject-junk]
+  additional_dependencies: [uv]
 - id: check-sdist-isolated
   name: check sdist (isolated)
   description: Check the contents of the SDist (isolated build)

--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ files.
 To run:
 
 ```console
-$ pipx run check-sdist
+$ pipx run check-sdist[uv]
 ```
 
 You can add `--no-isolation` to disable build isolation (faster, but must
 preinstall build dependencies), `--source-dir` to select a different source
 directory to check, and `--inject-junk` to temporarily inject some common junk
-files while running.
+files while running. You can select an installer for build to use with
+`--installer=`, choices are `uv`, `pip`, or `uv|pip`, which will use uv if
+available (the default).
 
 If you need the latest development version:
 
@@ -95,5 +97,5 @@ have this capability).
 - [check-manifest](https://github.com/mgedmin/check-manifest): A (currently)
   setuptools specific checker that can suggest possible ways to include/exclude
   files.
-- [scikit-hep developer pages](https://scikit-hep.org/developer): Guidelines on
-  which this package was designed.
+- [Scientific Python Development Guide](https://learn.scientific-python.org/development/):
+  Guidelines on which this package was designed.

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import nox
 
-nox.options.sessions = ["lint", "pylint", "tests"]
+nox.needs_version = ">=2024.4.15"
+nox.options.default_venv_backend = "uv|virtualenv"
 
 
 @nox.session
@@ -21,7 +22,7 @@ def pylint(session: nox.Session) -> None:
     """
     # This needs to be installed into the package environment, and is slower
     # than a pre-commit check
-    session.install(".", "pylint")
+    session.install("-e.", "pylint")
     session.run("pylint", "src", *session.posargs)
 
 
@@ -30,7 +31,7 @@ def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.
     """
-    session.install(".[test]")
+    session.install("-e.[test]")
     session.run("pytest", *session.posargs)
 
 
@@ -44,7 +45,7 @@ def coverage(session: nox.Session) -> None:
     tests(session)
 
 
-@nox.session
+@nox.session(default=False)
 def build(session: nox.Session) -> None:
     """
     Build an SDist and wheel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "build",
+  "build >=1.2",
+  "importlib-resources; python_version<'3.9'",
   "pathspec",
   "tomli; python_version<'3.11'",
-  "importlib-resources; python_version<'3.9'",
 ]
 keywords = ["sdist", "packaging", "lint"]
 
@@ -42,6 +42,9 @@ test = [
 dev = [
   "pytest >=6",
   "pytest-cov >=3",
+]
+uv = [
+  "uv",
 ]
 
 [project.urls]
@@ -89,8 +92,10 @@ disallow_incomplete_defs = true
 
 
 [tool.ruff]
-select = [
-  "E", "F", "W", # flake8
+src = ["src"]
+
+[tool.ruff.lint]
+extend-select = [
   "B",           # flake8-bugbear
   "I",           # isort
   "ARG",         # flake8-unused-arguments
@@ -111,13 +116,10 @@ select = [
   "YTT",         # flake8-2020
   "EXE",         # flake8-executable
 ]
-extend-ignore = [
-  "PLR",    # Design related pylint codes
+ignore = [
+  "PLR09",  # Design related pylint codes
   "E501",   # Line too long
-]
-src = ["src"]
-unfixable = [
-  "F841", # Removes unused variables
+  "ISC001", # Conflicts with formatter
 ]
 flake8-unused-arguments.ignore-variadic-names = true
 isort.required-imports = ["from __future__ import annotations"]

--- a/src/check_sdist/sdist.py
+++ b/src/check_sdist/sdist.py
@@ -5,13 +5,24 @@ import sys
 import tarfile
 import tempfile
 from pathlib import Path
+from typing import Literal
 
 
-def sdist_files(source_dir: Path, isolated: bool) -> frozenset[str]:
+def sdist_files(
+    source_dir: Path, *, isolated: bool, installer: Literal["uv", "pip"]
+) -> frozenset[str]:
     """Return the files that would be (are) placed in the SDist."""
 
     with tempfile.TemporaryDirectory() as outdir:
-        cmd = [sys.executable, "-m", "build", "--sdist", "--outdir", outdir]
+        cmd = [
+            sys.executable,
+            "-m",
+            "build",
+            "--sdist",
+            "--outdir",
+            outdir,
+            f"--installer={installer}",
+        ]
         if not isolated:
             cmd.append("--no-isolation")
         subprocess.run(cmd, check=True, cwd=source_dir)
@@ -31,4 +42,4 @@ def sdist_files(source_dir: Path, isolated: bool) -> frozenset[str]:
 
 
 if __name__ == "__main__":
-    print(*sorted(sdist_files(Path.cwd(), True)), sep="\n")
+    print(*sorted(sdist_files(Path.cwd(), isolated=True, installer="pip")), sep="\n")


### PR DESCRIPTION
Adding `--installer` option, requires build 1.2. Defaults to `uv|pip`, which uses `uv` if available.
