### PR TITLE
ci: macos-latest now points at macos-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,13 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.12"]
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest, macos-13, windows-latest]
 
         include:
           - python-version: pypy-3.8
             runs-on: ubuntu-latest
+          - python-version: "3.10"
+            runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
ARM is fine, no Python 3.8-3.9 is not.