### PR TITLE
tests: drop setuptools build

### DIFF
--- a/tests/downstream.toml
+++ b/tests/downstream.toml
@@ -9,11 +9,6 @@ ref = "0.3.2"
 fail = 2
 
 [[packages]]
-repo = "pypa/setuptools"
-ref = "v67.6.1"
-fail = 2
-
-[[packages]]
 repo = "scikit-build/scikit-build-core"
 ref = "v0.2.1"
 


### PR DESCRIPTION
I don't think setuptools really is meant to build itself with build, so let's just drop this. We are hitting the same thing as https://github.com/pypa/build/pull/820 and https://github.com/python/importlib_metadata/issues/508 if we upgrade the setuptools tag here.
