### PR TITLE
feat: use uv build directly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,8 @@ repos:
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: "v3.3.3"
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
@@ -47,13 +47,12 @@ repos:
         files: src|tests
         args: []
         additional_dependencies:
-          [
-            "tomli",
-            "pathspec",
-            "importlib-resources",
-            "pytest",
-            "validate-pyproject",
-          ]
+          - tomli
+          - pathspec
+          - importlib-resources
+          - pytest
+          - validate-pyproject
+          - uv
 
   - repo: https://github.com/henryiii/check-sdist
     rev: "v1.0.0"

--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ To use the [pre-commit](https://pre-commit.com) integration, put this in your
 This requires your build dependencies, but in doing so, it can cache the
 environment, making it quite fast. The installation is handled by pre-commit;
 see [`pre-commit-uv`](https://pypi.org/p/pre-commit-uv) if you want to try to
-optimize the initial setup. If you don't mind slower runs and don't want to
-require a build dependency listing:
+optimize the initial setup. If uv is present (including in your
+`additional_dependencies`), the build will be slightly faster, as uv is used to
+do the build. If you don't mind slower runs and don't want to require a build
+dependency listing:
 
 ```yaml
 - repo: https://github.com/henryiii/check-sdist

--- a/src/check_sdist/__main__.py
+++ b/src/check_sdist/__main__.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import importlib.util
-import shutil
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal
@@ -15,7 +13,7 @@ from ._compat import tomllib
 from .git import git_files
 from .inject import inject_junk_files
 from .resources import resources
-from .sdist import sdist_files
+from .sdist import get_uv, sdist_files
 
 
 def select_installer(
@@ -26,10 +24,7 @@ def select_installer(
     or throws an error if uv was required and not available.
     """
     if "uv" in installer:
-        if importlib.util.find_spec("uv") is not None:
-            return "uv"
-
-        if shutil.which("uv") is not None:
+        if get_uv() is not None:
             return "uv"
 
         if installer == "uv":

--- a/tests/test_downstream.py
+++ b/tests/test_downstream.py
@@ -7,6 +7,7 @@ import pytest
 
 from check_sdist.__main__ import compare
 from check_sdist._compat import tomllib
+from check_sdist.sdist import get_uv
 
 DIR = Path(__file__).parent.resolve()
 
@@ -15,9 +16,18 @@ with DIR.joinpath("downstream.toml").open("rb") as f:
 
 
 @pytest.mark.parametrize(
+    "installer",
+    [
+        pytest.param(
+            "uv", marks=pytest.mark.skipif(get_uv() is None, reason="uv not found")
+        ),
+        "pip",
+    ],
+)
+@pytest.mark.parametrize(
     ("repo", "ref", "fail"), [(x["repo"], x["ref"], x.get("fail", 0)) for x in packages]
 )
-def test_packages(repo, ref, fail, tmp_path, monkeypatch):
+def test_packages(repo, ref, fail, tmp_path, monkeypatch, installer):
     monkeypatch.chdir(tmp_path)
     cmd = [
         "git",
@@ -29,4 +39,4 @@ def test_packages(repo, ref, fail, tmp_path, monkeypatch):
     ]
     subprocess.run(cmd, check=True)
     package_path = tmp_path / repo.split("/")[1]
-    assert compare(package_path, isolated=True) == fail
+    assert compare(package_path, isolated=True, installer=installer) == fail


### PR DESCRIPTION
This uses `uv build`, which is somewhat recent. Saves a tiny bit of time.

- **tests: run both pip and uv tests**
- **feat: use uv build directly**

Idea from #58.
