### PR TITLE
feat: read build-backend ignore lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ you use this.
 
 You can tell check-sdist to look for exclude lists for a specific build backend
 with `build-backend`, or `"none"` to only use it's own exclude list. Build
-backends supported are `"flit_core.buildapi"`, `"hatchling.build"`, and
-`"scikit_build_core.build"`. The default, `"auto"`, will try to detect the build
+backends supported are `"flit_core.buildapi"`, `"hatchling.build"`,
+`"scikit_build_core.build"`, `"pdm.backend"`, `"maturin"`, and
+`"poetry.core.masonry.api"`. The default, `"auto"`, will try to detect the build
 backend if `build-system.build-backend` is set to a known value.
 
 ### See also

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ git-only = []
 default-ignore = true
 recurse-submodules = true
 mode = "git"
+build-backend = "auto"
 ```
 
 You can add `.gitignore` style lines here, and you can turn off the default
@@ -111,6 +112,12 @@ have this capability).
 You can also select `mode = "all"`, which will instead check every file on your
 system. Be prepared to ignore lots of things manually, like `*.pyc` files, if
 you use this.
+
+You can tell check-sdist to look for exclude lists for a specific build backend
+with `build-backend`, or `"none"` to only use it's own exclude list. Build
+backends supported are `"flit_core.buildapi"`, `"hatchling.build"`, and
+`"scikit_build_core.build"`. The default, `"auto"`, will try to detect the build
+backend if `build-system.build-backend` is set to a known value.
 
 ### See also
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ testpaths = [
 
 [tool.coverage]
 run.source = ["check_sdist"]
+report.exclude_also = [
+    "return __all__",
+]
 
 
 [tool.mypy]

--- a/src/check_sdist/backends.py
+++ b/src/check_sdist/backends.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pathspec
+
+
+def backend_ignored_patterns(
+    backend: str, pyproject: dict[str, Any], files: frozenset[str]
+) -> frozenset[str]:
+    """
+    Return the ignored patterns for the given backend. If the generator is
+    "none", then no patterns are ignored. If the generator is "auto", then the
+    value is read from the pyproject.toml file. Any recognized backend can also
+    be specified directly.
+    """
+
+    if backend == "none":
+        return files
+
+    backend_resolved = (
+        pyproject.get("build-system", {}).get(
+            "build-backend", "setuptools.build_meta.__legacy__"
+        )
+        if backend == "auto"
+        else backend
+    )
+
+    if backend_resolved == "flit_core.buildapi":
+        flit_core_exclude = (
+            pyproject.get("tool", {})
+            .get("flit", {})
+            .get("sdist", {})
+            .get("exclude", [])
+        )
+        for pattern in flit_core_exclude:
+            results = {str(p) for p in Path().glob(pattern)}
+            files = files - results
+        return files
+    if backend_resolved == "hatchling.build":
+        hatch_exclude = (
+            pyproject.get("tool", {})
+            .get("hatch", {})
+            .get("build", {})
+            .get("targets", {})
+            .get("sdist", {})
+            .get("exclude", [])
+        )
+        sdist_spec = pathspec.GitIgnoreSpec.from_lines(hatch_exclude)
+        return frozenset(p for p in files if not sdist_spec.match_file(p))
+    if backend_resolved == "scikit_build_core.build":
+        hatch_exclude = (
+            pyproject.get("tool", {})
+            .get("scikit-build", {})
+            .get("sdist", {})
+            .get("exclude", [])
+        )
+        sdist_spec = pathspec.GitIgnoreSpec.from_lines(hatch_exclude)
+        return frozenset(p for p in files if not sdist_spec.match_file(p))
+    if backend != "auto":
+        msg = f"Unknown backend: {backend} - please add support in check_dist.backends"
+        raise ValueError(msg)
+    return files

--- a/src/check_sdist/resources/check-sdist.schema.json
+++ b/src/check_sdist/resources/check-sdist.schema.json
@@ -33,6 +33,17 @@
       "description": "What to use as baseline",
       "default": "git",
       "enum": ["git", "all"]
+    },
+    "build-backend": {
+      "description": "What to expect as build-backend, in order to look for exclude lists",
+      "default": "auto",
+      "enum": [
+        "auto",
+        "none",
+        "flit_core.buildapi",
+        "hatchling.build",
+        "scikit_build_core.build"
+      ]
     }
   }
 }

--- a/src/check_sdist/resources/check-sdist.schema.json
+++ b/src/check_sdist/resources/check-sdist.schema.json
@@ -42,7 +42,10 @@
         "none",
         "flit_core.buildapi",
         "hatchling.build",
-        "scikit_build_core.build"
+        "scikit_build_core.build",
+        "pdm.backend.api",
+        "poetry.core.masonry.api",
+        "maturin"
       ]
     }
   }

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -167,14 +167,13 @@ def test_pdm_backend(backend: str):
     )
 
 
-@pytest.mark.skip
 @pytest.mark.usefixtures("git_dir")
 @pytest.mark.parametrize("backend", ["auto", "none"])
 def test_maturin(backend: str):
     Path("pyproject.toml").write_text(
         inspect.cleandoc(f"""
             [build-system]
-            requires = ["maturin"]
+            requires = ["maturin~=1.0"]
             build-backend = "maturin"
 
             [project]
@@ -182,6 +181,7 @@ def test_maturin(backend: str):
             version = "0.1.0"
 
             [tool.maturin]
+            features = ["pyo3/extension-module"]
             exclude = ["ignore*", "some-file", "**/notme.txt"]
 
             [tool.check-sdist]
@@ -194,6 +194,9 @@ def test_maturin(backend: str):
             name = "guessing-game"
             version = "0.1.0"
             edition = "2021"
+
+            [dependencies.pyo3]
+            version = "0.22.4"
         """)
     )
     Path("src").mkdir()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -259,5 +259,5 @@ def test_unknown_backend():
 
     subprocess.run(["git", "add", "."], check=True)
     subprocess.run(["git", "commit", "-m", "Initial commit"], check=True)
-    with pytest.raises(ValueError, match="Unknown backend: unknown") as excinfo:
+    with pytest.raises(ValueError, match="Unknown backend: unknown"):
         compare(Path(), isolated=True, verbose=True)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import inspect
 import os
+import subprocess
 from pathlib import Path
+
+import pytest
 
 from check_sdist.__main__ import compare
 from check_sdist.inject import inject_junk_files
@@ -27,3 +31,92 @@ def test_self_dir_injected():
         assert compare(DIR.parent, isolated=True) == 0
     end = get_all_files(DIR.parent)
     assert start == end
+
+
+@pytest.fixture
+def git_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init"], check=True)
+    subprocess.run(["git", "config", "user.email", "ci@example.com"], check=True)
+    subprocess.run(["git", "config", "user.name", "CI"], check=True)
+    return tmp_path
+
+
+@pytest.mark.usefixtures("git_dir")
+@pytest.mark.parametrize("backend", ["auto", "none"])
+def test_hatchling(backend: str):
+    Path("pyproject.toml").write_text(
+        inspect.cleandoc(f"""
+            [build-system]
+            requires = ["hatchling"]
+            build-backend = "hatchling.build"
+
+            [project]
+            name = "hatchling-test"
+            version = "0.1.0"
+
+            [tool.hatch]
+            build.targets.sdist.exclude = ["ignore*", "some-file", "**/notme.txt"]
+
+            [tool.check-sdist]
+            build-backend = "{backend}"
+        """)
+    )
+    Path(".gitignore").write_text(
+        inspect.cleandoc("""
+        some-ignored-file.txt
+    """)
+    )
+    Path("ignore-me.txt").touch()
+    Path("not-ignored.txt").touch()
+    Path("some-file").touch()
+    Path("some-dir").mkdir()
+    Path("some-dir/notme.txt").touch()
+    subprocess.run(["git", "add", "."], check=True)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], check=True)
+    Path("some-ignored-file.txt").touch()
+    assert compare(Path(), isolated=True, verbose=True) == (
+        0 if backend == "auto" else 2
+    )
+
+
+@pytest.mark.usefixtures("git_dir")
+@pytest.mark.parametrize("backend", ["auto", "none"])
+def test_flit_core(backend: str):
+    Path("pyproject.toml").write_text(
+        inspect.cleandoc(f"""
+            [build-system]
+            requires = ["flit-core"]
+            build-backend = "flit_core.buildapi"
+
+            [project]
+            name = "flit-core-test"
+            version = "0.1.0"
+            description = "A test package"
+
+            [tool.flit.sdist]
+            include = ["not-ignored.txt", ".gitignore"]
+            exclude = ["ignore*", "some-file", "**/notme.txt"]
+
+            [tool.check-sdist]
+            build-backend = "{backend}"
+        """)
+    )
+    Path(".gitignore").write_text(
+        inspect.cleandoc("""
+        some-ignored-file.txt
+    """)
+    )
+    Path("ignore-me.txt").touch()
+    Path("not-ignored.txt").touch()
+    Path("some-file").touch()
+    Path("some-dir").mkdir()
+    Path("some-dir/notme.txt").touch()
+    Path("flit_core_test").mkdir()
+    Path("flit_core_test/__init__.py").touch()
+    subprocess.run(["git", "add", "."], check=True)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], check=True)
+    Path("some-ignored-file.txt").touch()
+    assert compare(Path(), isolated=True, verbose=True) == (
+        0 if backend == "auto" else 2
+    )

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -46,11 +46,14 @@ def git_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     )
     Path("example").mkdir()
     Path("example/__init__.py").touch()
+    Path("example/notme.py").touch()
     Path("ignore-me.txt").touch()
     Path("not-ignored.txt").touch()
     Path("some-file").touch()
     Path("some-dir").mkdir()
-    Path("some-dir/notme.txt").touch()
+    Path("some-dir/notme.py").touch()
+    Path("some-dir/more-dir").mkdir()
+    Path("some-dir/more-dir/notme.py").touch()
     Path("some-ignored-file.txt").touch()
 
     return tmp_path
@@ -70,7 +73,7 @@ def test_hatchling(backend: str):
             version = "0.1.0"
 
             [tool.hatch]
-            build.targets.sdist.exclude = ["ignore*", "some-file", "**/notme.txt"]
+            build.targets.sdist.exclude = ["ignore*", "some-file", "**/notme.py"]
 
             [tool.check-sdist]
             build-backend = "{backend}"
@@ -99,7 +102,7 @@ def test_flit_core(backend: str):
 
             [tool.flit.sdist]
             include = ["not-ignored.txt", ".gitignore"]
-            exclude = ["ignore*", "some-file", "**/notme.txt"]
+            exclude = ["ignore*", "some-file", "**/notme.py"]
 
             [tool.check-sdist]
             build-backend = "{backend}"
@@ -126,7 +129,7 @@ def test_scikit_build_core(backend: str):
             version = "0.1.0"
 
             [tool.scikit-build]
-            sdist.exclude = ["ignore*", "some-file", "**/notme.txt"]
+            sdist.exclude = ["ignore*", "some-file", "**/notme.py"]
 
             [tool.check-sdist]
             build-backend = "{backend}"
@@ -154,7 +157,7 @@ def test_pdm_backend(backend: str):
 
             [tool.pdm]
             build.source-includes = [".gitignore", "not-ignored.txt"]
-            build.excludes = ["ignore*", "some-file", "**/notme.txt"]
+            build.excludes = ["ignore*", "some-file", "**/notme.py"]
 
             [tool.check-sdist]
             build-backend = "{backend}"
@@ -182,7 +185,7 @@ def test_maturin(backend: str):
 
             [tool.maturin]
             features = ["pyo3/extension-module"]
-            exclude = ["ignore*", "some-file", "**/notme.txt"]
+            exclude = ["ignore*", "some-file", "**/notme.py"]
 
             [tool.check-sdist]
             build-backend = "{backend}"
@@ -223,7 +226,7 @@ def test_poetry_core(backend: str):
             authors = []
             description = "A test package."
             include = [".gitignore", "not-ignored.txt"]
-            exclude = ["ignore*", {{path="some-file", format=["sdist"]}}, "**/notme.txt"]
+            exclude = ["ignore*", {{path="some-file", format=["sdist"]}}, "**/notme.py"]
 
             [tool.check-sdist]
             build-backend = "{backend}"


### PR DESCRIPTION
Covering common build backends that have pyproject.toml-based ignore lists.

- [x] Should also do an ignore of a Python file in a package in tests.
- [x] Add enough to make maturin test runnable.

I'm not adding Setuptools (not configured in pyproject.toml) or meson-python (seems to be configured from meson).