### PR TITLE
Fix a bug in sdist-only file detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ backends supported are `"flit_core.buildapi"`, `"hatchling.build"`,
 `"poetry.core.masonry.api"`. The default, `"auto"`, will try to detect the build
 backend if `build-system.build-backend` is set to a known value.
 
+check-sdist will ignore `*.dist-info` in SDists, since those are generated. If
+the build backend is clearly setuptools, it will also ignore `*.egg-info`, as
+setuptools generates this. If you've wrapped your build backend, you'll need to
+add this to the `sdist-only` ignore list manually.
+
 ### See also
 
 - [check-manifest](https://github.com/mgedmin/check-manifest): A (currently)

--- a/src/check_sdist/__main__.py
+++ b/src/check_sdist/__main__.py
@@ -88,6 +88,14 @@ def compare(
         with resources.joinpath("default-ignore.txt").open("r", encoding="utf-8") as f:
             git_only_patterns.extend(f.read().splitlines())
         sdist_only_patterns.append("*.dist-info")
+        build_backend = pyproject.get("build-system", {}).get(
+            "build-backend", "setuptools.build_meta.__legacy__"
+        )
+        if build_backend in {
+            "setuptools.build_meta",
+            "setuptools.build_meta.__legacy__",
+        }:
+            sdist_only_patterns.append("*.egg-info")
 
     sdist_spec = pathspec.GitIgnoreSpec.from_lines(sdist_only_patterns)
     git_spec = pathspec.GitIgnoreSpec.from_lines(git_only_patterns)

--- a/tests/downstream.toml
+++ b/tests/downstream.toml
@@ -1,25 +1,25 @@
 [[packages]]
 repo = "pypa/build"
-ref = "1.2.2.post1"
+ref = "1.3.0"
 
 [[packages]]
 repo = "FriedrichFroebel/pelican-youtube-thumbnails"
 ref = "0.3.3"
-fail = 2
+fail = 3
 
 [[packages]]
 repo = "scikit-build/scikit-build-core"
-ref = "v0.11.2"
+ref = "v0.11.6"
 
 [[packages]]
 repo = "scikit-build/scikit-build"
-ref = "0.18.0"
+ref = "0.18.1"
 
 [[packages]]
 repo = "pybind/pybind11"
-ref = "v2.13.6"
-fail = 2
+ref = "v3.0.1"
 
 [[packages]]
 repo = "isce-framework/snaphu-py"
 ref = "v0.4.1"
+fail = 1

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -185,7 +185,7 @@ def test_maturin(backend: str):
 
             [tool.maturin]
             features = ["pyo3/extension-module"]
-            exclude = ["ignore*", "some-file", "**/notme.py"]
+            exclude = ["ignore*", "some-file", "**/notme.py", "Cargo.lock"]
 
             [tool.check-sdist]
             build-backend = "{backend}"


### PR DESCRIPTION
The default ignore rule for `*.dist-info` was accidentally exploded. As a result, `*` is inserted into the sdist spec.

---

While adding `check-sdist` to a project, I found that I had `.mypy_cache/` directories in my sdist. (Classic issue; these are `.gitignore: *` dirs.)
`check-sdist` didn't detect them. While trying to understand to file a good bug report, I found the fix.
