### PR TITLE
chore: add minimum version test job to noxfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,19 @@ jobs:
           plugin: pycoverage
           name: Python ${{ matrix.python-version}}
 
+  minimums:
+    name: Test minimum dependency versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v8.0.0
+
+      - name: Test with minimum versions
+        run: uvx nox -s minimums
+
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
@@ -79,7 +92,7 @@ jobs:
 
   pass:
     if: always()
-    needs: [pylint, checks, dist]
+    needs: [pylint, checks, minimums, dist]
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@release/v1

--- a/noxfile.py
+++ b/noxfile.py
@@ -62,6 +62,16 @@ def coverage(session: nox.Session) -> None:
     tests(session)
 
 
+@nox.session(venv_backend="uv", default=False, python="3.9")
+def minimums(session: nox.Session) -> None:
+    """
+    Test the minimum versions of dependencies.
+    """
+    test_grp = nox.project.dependency_groups(PYPROJECT, "test")
+    session.install("-e.", *test_grp, "--resolution=lowest-direct")
+    session.run("pytest", "-nauto", *session.posargs, env={"COVERAGE_CORE": "sysmon"})
+
+
 @nox.session(default=False)
 def build(session: nox.Session) -> None:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
   "build >=1.2",
-  "pathspec",
+  "pathspec >=0.10",
   "tomli; python_version<'3.11'",
 ]
 keywords = ["sdist", "packaging", "lint"]
@@ -54,8 +54,8 @@ check-sdist = "check_sdist.schema:get_schema"
 test = [
   "pytest >=7",
   "pytest-cov >=3",
-  "pytest-xdist",
-  "pyproject-hooks !=1.1.0",
+  "pytest-xdist >=3",
+  "pyproject-hooks >=1.0",
   "validate-pyproject >=0.16",
 ]
 dev = [{ include-group = "test" }]


### PR DESCRIPTION
:robot: Used https://github.com/henryiii/skills - `add-minimum-job` skill.

## Description

This PR adds a `minimums` nox session to test the package with the lowest direct dependency versions. This helps ensure that declared minimum version constraints in `pyproject.toml` are correct and that the package works with those versions.

## Changes

### New noxfile.py session
- Added `minimums` session that uses Python 3.9 (minimum supported version)
- Configured to use `uv` venv backend for fast environment creation
- Installs dependencies with `--resolution=lowest-direct` flag
- Runs the full test suite against minimum versions

### Updated dependencies in pyproject.toml
- `pathspec`: Added minimum version constraint `>=0.10` (was unpinned)
- `pytest-xdist`: Added minimum version constraint `>=3` (was unpinned)
- `pyproject-hooks`: Changed from excluded version `!=1.1.0` to minimum version `>=1.0`

## Testing

✅ All 39 tests pass with minimum dependencies (Python 3.9)
✅ All 39 tests pass with current dependencies (Python 3.14)

## Usage

Run the minimum version tests:
```bash
nox -s minimums
```

This can be integrated into CI/CD workflows to ensure minimum versions remain valid on every commit.
