### PR TITLE
Add Python 3.15 to classifiers and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.14"]
+        python-version: ["3.9", "3.15"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
         include:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Typing :: Typed",
 ]
 dependencies = [


### PR DESCRIPTION
Adds Python 3.15 support:

- Add the `Programming Language :: Python :: 3.15` classifier in `pyproject.toml`.
- Bump the upper end of the CI test matrix from 3.14 to 3.15 (prereleases are already allowed via `allow-prereleases: true`).

https://claude.ai/code/session_01StM1kuQFuZjfec3hNw7ZiR

---
_Generated by [Claude Code](https://claude.ai/code/session_01StM1kuQFuZjfec3hNw7ZiR)_