### PR TITLE
fix: inject junk files for the duration of compare()

### DIFF
--- a/src/check_sdist/__main__.py
+++ b/src/check_sdist/__main__.py
@@ -176,14 +176,14 @@ def main(sys_args: Sequence[str] | None = None, /) -> None:
         if args.inject_junk:
             stack.enter_context(inject_junk_files(args.source_dir))
 
-    raise SystemExit(
-        compare(
-            args.source_dir,
-            isolated=not args.no_isolation,
-            verbose=args.verbose,
-            installer=args.installer,
+        raise SystemExit(
+            compare(
+                args.source_dir,
+                isolated=not args.no_isolation,
+                verbose=args.verbose,
+                installer=args.installer,
+            )
         )
-    )
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,10 @@ import pytest
 from check_sdist import __version__
 from check_sdist.__main__ import main
 
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 def test_version(capsys: pytest.CaptureFixture[str]):
     with pytest.raises(SystemExit):
@@ -13,3 +17,23 @@ def test_version(capsys: pytest.CaptureFixture[str]):
     out, err = capsys.readouterr()
     assert out == f"check-sdist {__version__}\n"
     assert not err
+
+
+def test_inject_junk_present_during_compare(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """--inject-junk must inject before compare() runs, not after."""
+    present = None
+
+    def fake_compare(source_dir: Path, **_: object) -> int:
+        nonlocal present
+        present = source_dir.joinpath("__pycache__").is_dir()
+        return 0
+
+    monkeypatch.setattr("check_sdist.__main__.compare", fake_compare)
+
+    with pytest.raises(SystemExit):
+        main(["--inject-junk", "--source-dir", str(tmp_path)])
+
+    assert present is True
+    assert not tmp_path.joinpath("__pycache__").exists()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

`--inject-junk` has never actually injected files during the build. In `main()`, the junk files were injected inside a `with contextlib.ExitStack()` block, but `compare()` (which builds the SDist) was called *after* that block closed:

```python
with contextlib.ExitStack() as stack:
    if args.inject_junk:
        stack.enter_context(inject_junk_files(args.source_dir))

raise SystemExit(compare(...))   # <- junk already cleaned up here
```

So the junk files were created and immediately removed before the SDist was ever built, making `--inject-junk` a no-op. This dates back to the original `--inject-junk` commit (51686ba, 2023).

## Fix

Move the `compare()` call inside the `with` block so the injected junk persists while the SDist is built.

## Test

Added a regression test in `tests/test_cli.py` that monkeypatches `compare` to assert an injected junk path (`__pycache__`) exists at call time, and that it's cleaned up afterward. Verified it fails on the old code and passes on the fix.