### PR TITLE
fix: correct pdm-backend build-backend value in schema

### DIFF
--- a/scripts/generate_schema.py
+++ b/scripts/generate_schema.py
@@ -49,7 +49,7 @@ properties:
       - flit_core.buildapi
       - hatchling.build
       - scikit_build_core.build
-      - pdm.backend.api
+      - pdm.backend
       - poetry.core.masonry.api
       - maturin
 """

--- a/src/check_sdist/resources/check-sdist.schema.json
+++ b/src/check_sdist/resources/check-sdist.schema.json
@@ -43,7 +43,7 @@
         "flit_core.buildapi",
         "hatchling.build",
         "scikit_build_core.build",
-        "pdm.backend.api",
+        "pdm.backend",
         "poetry.core.masonry.api",
         "maturin"
       ]

--- a/tests/test_validate_pyproject.py
+++ b/tests/test_validate_pyproject.py
@@ -32,6 +32,26 @@ def test_validate_pyproject_extra_key():
         validator(example)
 
 
+@pytest.mark.parametrize(
+    "backend",
+    [
+        "auto",
+        "none",
+        "flit_core.buildapi",
+        "hatchling.build",
+        "scikit_build_core.build",
+        "pdm.backend",
+        "poetry.core.masonry.api",
+        "maturin",
+    ],
+)
+def test_validate_pyproject_build_backend(backend: str):
+    """The schema must accept the build-backend strings the code matches on."""
+    example = {"tool": {"check-sdist": {"build-backend": backend}}}
+    validator = validate_pyproject.api.Validator()
+    assert validator(example) is not None
+
+
 def test_validate_pyproject_invalid_value():
     example = {
         "tool": {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

The `[tool.check-sdist]` settings schema listed `pdm.backend.api` as an allowed `build-backend` value, but that string is wrong in both directions:

- pdm-backend's actual build-backend is `pdm.backend` — that's what `backends.py` matches on (`backends.py:83`), what the README documents, and what `test_package.py` uses.
- A user who correctly sets `build-backend = "pdm.backend"` in `[tool.check-sdist]` would have it **rejected** by `validate-pyproject`, since the enum didn't include it.
- A user who set the enum's `pdm.backend.api` to satisfy the schema would hit the "Unknown backend" `ValueError` in `backends.py`.

## Fix

- Correct the enum value to `pdm.backend` in `scripts/generate_schema.py` (the source of truth) and regenerate `check-sdist.schema.json`.
- Add a parametrized test asserting every supported `build-backend` string validates against the schema, so the schema and the code can't drift again.

Verified the new test fails on the old schema value and passes with the fix.