### PR TITLE
chore: minor cleanups from code review (issue #163 items 3-6)

### DIFF
--- a/src/check_sdist/__main__.py
+++ b/src/check_sdist/__main__.py
@@ -70,7 +70,7 @@ def compare(
     conditions are true.
     """
 
-    installer = select_installer(installer)
+    resolved_installer = select_installer(installer)
 
     pyproject = {}
     config = {}
@@ -86,7 +86,7 @@ def compare(
     mode = config.get("mode", "git")
     backend = config.get("build-backend", "auto")
 
-    sdist = sdist_files(source_dir, isolated=isolated, installer=installer) - {
+    sdist = sdist_files(source_dir, isolated=isolated, installer=resolved_installer) - {
         "PKG-INFO"
     }
     if mode == "git":

--- a/src/check_sdist/backends.py
+++ b/src/check_sdist/backends.py
@@ -99,6 +99,6 @@ def backend_ignored_patterns(
         exclude = pyproject.get("tool", {}).get("maturin", {}).get("exclude", [])
         return glob_filter(exclude, files)
     if backend != "auto":
-        msg = f"Unknown backend: {backend} - please add support in check_dist.backends"
+        msg = f"Unknown backend: {backend} - please add support in check_sdist.backends"
         raise ValueError(msg)
     return files

--- a/src/check_sdist/inject.py
+++ b/src/check_sdist/inject.py
@@ -44,7 +44,7 @@ def inject_files(source_dir: Path, files: Sequence[str]) -> Generator[None, None
         for injected in injected_files:
             injected.unlink()
         for injected in sorted(
-            injected_directories, key=lambda x: len(str(x)), reverse=True
+            injected_directories, key=lambda x: len(x.parts), reverse=True
         ):
             injected.rmdir()
 

--- a/src/check_sdist/sdist.py
+++ b/src/check_sdist/sdist.py
@@ -64,13 +64,14 @@ def sdist_files(
         (outpath,) = Path(outdir).glob("*.tar.gz")
 
         with tarfile.open(outpath) as tar:
-            prefixes = {n.split("/", maxsplit=1)[0] for n in tar.getnames()}
+            members = tar.getmembers()
+            prefixes = {m.name.split("/", maxsplit=1)[0] for m in members}
             if len(prefixes) != 1:
                 msg = f"malformed SDist, contains multiple packages {prefixes}"
                 raise AssertionError(msg)
             return frozenset(
                 t.name.split("/", maxsplit=1)[1]
-                for t in tar.getmembers()
+                for t in members
                 if t.isfile() or t.issym()
             )
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Four low-risk cleanups from issue #163:

- **Typo fix** (`backends.py`): error message referenced `check_dist.backends` → corrected to `check_sdist.backends`
- **Directory removal ordering** (`inject.py`): replaced `len(str(x))` with `len(x.parts)` for deepest-first ordering — more semantically correct for path depth
- **Single tar traversal** (`sdist.py`): `sdist_files` previously called `tar.getnames()` then `tar.getmembers()`; refactored to call `tar.getmembers()` once and derive prefixes from that list
- **Installer type annotation** (`__main__.py`): introduced `resolved_installer` local variable to hold the narrowed `Literal["uv", "pip"]` return of `select_installer()`, avoiding reassignment of the broader `Literal["uv", "pip", "uv|pip"]` parameter

Refs #163