### PR TITLE
fix: glob backend excludes relative to source_dir, not cwd

### DIFF
--- a/src/check_sdist/__main__.py
+++ b/src/check_sdist/__main__.py
@@ -110,7 +110,7 @@ def compare(
     sdist_only = frozenset(p for p in sdist - git if not sdist_spec.match_file(p))
     git_only = frozenset(p for p in git - sdist if not git_spec.match_file(p))
 
-    git_only = backend_ignored_patterns(backend, pyproject, git_only)
+    git_only = backend_ignored_patterns(backend, pyproject, git_only, source_dir)
 
     if verbose:
         print("SDist contents:")

--- a/src/check_sdist/backends.py
+++ b/src/check_sdist/backends.py
@@ -14,13 +14,17 @@ def __dir__() -> list[str]:
     return __all__
 
 
-def glob_filter(patterns: list[str], files: frozenset[str]) -> frozenset[str]:
+def glob_filter(
+    patterns: list[str], files: frozenset[str], source_dir: Path
+) -> frozenset[str]:
     """
-    Filter out files based on glob patterns.
+    Filter out files based on glob patterns, relative to source_dir.
     """
     new_files = set(files)
     for pattern in patterns:
-        results = {str(p.as_posix()) for p in Path().glob(pattern)}
+        results = {
+            p.relative_to(source_dir).as_posix() for p in Path(source_dir).glob(pattern)
+        }
         new_files -= results
     return frozenset(new_files)
 
@@ -34,7 +38,7 @@ def pathspec_filter(patterns: list[str], files: frozenset[str]) -> frozenset[str
 
 
 def backend_ignored_patterns(
-    backend: str, pyproject: dict[str, Any], files: frozenset[str]
+    backend: str, pyproject: dict[str, Any], files: frozenset[str], source_dir: Path
 ) -> frozenset[str]:
     """
     Return the ignored patterns for the given backend. If the generator is
@@ -61,7 +65,7 @@ def backend_ignored_patterns(
             .get("sdist", {})
             .get("exclude", [])
         )
-        return glob_filter(exclude, files)
+        return glob_filter(exclude, files, source_dir)
     if backend_resolved == "hatchling.build":
         exclude = (
             pyproject.get("tool", {})
@@ -87,17 +91,17 @@ def backend_ignored_patterns(
             .get("build", {})
             .get("excludes", [])
         )
-        return glob_filter(exclude, files)
+        return glob_filter(exclude, files, source_dir)
     if backend_resolved == "poetry.core.masonry.api":
         exclude = [
             x if isinstance(x, str) else x["path"]
             for x in pyproject.get("tool", {}).get("poetry", {}).get("exclude", [])
             if isinstance(x, str) or "sdist" in x.get("format", ["sdist"])
         ]
-        return glob_filter(exclude, files)
+        return glob_filter(exclude, files, source_dir)
     if backend_resolved == "maturin":
         exclude = pyproject.get("tool", {}).get("maturin", {}).get("exclude", [])
-        return glob_filter(exclude, files)
+        return glob_filter(exclude, files, source_dir)
     if backend != "auto":
         msg = f"Unknown backend: {backend} - please add support in check_dist.backends"
         raise ValueError(msg)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from check_sdist._compat import tomllib
+from check_sdist.backends import backend_ignored_patterns
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_glob_backend_excludes_relative_to_source_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Glob-based backend excludes must resolve against source_dir, not cwd."""
+    source_dir = tmp_path / "project"
+    source_dir.mkdir()
+    (source_dir / "junk.txt").touch()
+    (source_dir / "keep.py").touch()
+
+    # Run from an unrelated directory: the old code globbed the cwd and so
+    # never matched the excluded file living under source_dir.
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    pyproject = tomllib.loads(
+        """
+        [build-system]
+        build-backend = "pdm.backend"
+
+        [tool.pdm.build]
+        excludes = ["junk.txt"]
+        """
+    )
+    files = frozenset({"junk.txt", "keep.py"})
+
+    result = backend_ignored_patterns("auto", pyproject, files, source_dir)
+
+    assert "junk.txt" not in result
+    assert "keep.py" in result


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`backend_ignored_patterns` / `glob_filter` globbed the current working directory (`Path().glob(pattern)`) instead of the project source directory. The flit / pdm / poetry / maturin backend exclude lists were therefore matched against the wrong directory whenever the source dir differed from cwd (e.g. `--source-dir`, or tests that `chdir` elsewhere before calling `compare(package_path)`). This threads `source_dir` through both functions and globs `Path(source_dir)`, converting results back to posix paths relative to `source_dir` so they match the relative-path strings in `files`. The hatchling / scikit-build-core `pathspec_filter` path is unchanged (it matches strings, not the filesystem).

Refs #163