### PR TITLE
test: deflake test_self_dir by running against an isolated copy

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -18,7 +18,9 @@ DIR = Path(__file__).parent
 def self_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     shutil.copytree(
-        DIR.parent, repo, ignore=shutil.ignore_patterns("*venv*", "*cache*", "dist")
+        DIR.parent,
+        repo,
+        ignore=shutil.ignore_patterns("*venv*", "*cache*", "dist", ".nox"),
     )
     return repo
 
@@ -28,10 +30,13 @@ def get_all_files(path: Path) -> frozenset[str]:
         return frozenset(it.name for it in it if not it.name.startswith(".coverage"))
 
 
-def test_self_dir():
-    start = get_all_files(DIR.parent)
-    assert compare(DIR.parent, isolated=True) == 0
-    end = get_all_files(DIR.parent)
+def test_self_dir(self_repo: Path, monkeypatch: pytest.MonkeyPatch):
+    # Run against an isolated copy rather than the live repo, so concurrent
+    # tooling (pytest/mypy caches under -nauto) can't perturb the snapshot.
+    monkeypatch.chdir(self_repo)
+    start = get_all_files(Path())
+    assert compare(Path(), isolated=True) == 0
+    end = get_all_files(Path())
     assert start == end
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`test_self_dir` snapshotted the **live repo directory** (`DIR.parent`) before and after `compare()` and asserted the full top-level listing was unchanged. Because it runs with `pytest -nauto`, concurrent workers (and pytest/mypy themselves) can write cache directories into the repo root mid-test — e.g. `.pytest_cache` appearing between the two snapshots — producing a phantom diff. This intermittently reddened CI (seen on #165, where a plain re-run went green with no code change; the test is `isolated=True`, so `compare()` itself was never the cause).

This points `test_self_dir` at the existing `self_repo` fixture (a `copytree` of the repo into `tmp_path`), matching the sibling `test_self_dir_injected`. Nothing outside the test writes into that temp copy, so the race is eliminated by construction rather than filtered. `.nox` is also added to the fixture's ignore list to keep the copy small.

Verified locally: `tests/test_package.py` passes (15/15) on a clean tree.

Refs #163
