### PR TITLE
feat: add "none" default backend to the plugin system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,10 @@ Per-backend logic lives in the `backends/` package: one module per backend
 `sdist_only_ignores()`. Backends are registered under the `check_sdist.backends`
 entry-point group (keyed by build-backend string) and discovered via
 `backends/__init__.py::load_backends()`; `resolve_backend()` maps the
-`build-backend` config (`auto`/`none`/explicit) to a `Backend` or `None`. Users
-can register their own backends under the same entry-point group.
+`build-backend` config (`auto`/`none`/explicit) to a `Backend`, falling back to
+the no-op `NoneBackend` (`backends/none.py`) when `none` is selected or `auto`
+finds no match. Users can register their own backends under the same entry-point
+group.
 
 `compare()` returns a bitfield exit code: 1 = SDist has extra files, 2 = SDist
 is missing git files, 3 = both.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ check-sdist = "check_sdist.__main__:main"
 check-sdist = "check_sdist.schema:get_schema"
 
 [project.entry-points."check_sdist.backends"]
+"none" = "check_sdist.backends.none:NoneBackend"
 "setuptools.build_meta" = "check_sdist.backends.setuptools:SetuptoolsBackend"
 "flit_core.buildapi" = "check_sdist.backends.flit:FlitBackend"
 "hatchling.build" = "check_sdist.backends.hatchling:HatchlingBackend"

--- a/src/check_sdist/__main__.py
+++ b/src/check_sdist/__main__.py
@@ -103,8 +103,7 @@ def compare(
         with resources.joinpath("default-ignore.txt").open("r", encoding="utf-8") as f:
             git_only_patterns.update(f.read().splitlines())
         sdist_only_patterns.add("*.dist-info")
-        if backend is not None:
-            sdist_only_patterns.update(backend.sdist_only_ignores(pyproject))
+        sdist_only_patterns.update(backend.sdist_only_ignores(pyproject))
 
     sdist_spec = pathspec.GitIgnoreSpec.from_lines(sdist_only_patterns)
     git_spec = pathspec.GitIgnoreSpec.from_lines(git_only_patterns)
@@ -112,8 +111,7 @@ def compare(
     sdist_only = frozenset(p for p in sdist - git if not sdist_spec.match_file(p))
     git_only = frozenset(p for p in git - sdist if not git_spec.match_file(p))
 
-    if backend is not None:
-        git_only = backend.git_only_excludes(pyproject, git_only, source_dir)
+    git_only = backend.git_only_excludes(pyproject, git_only, source_dir)
 
     if verbose:
         print("SDist contents:")

--- a/src/check_sdist/backends/__init__.py
+++ b/src/check_sdist/backends/__init__.py
@@ -41,17 +41,14 @@ def load_backends() -> dict[str, Backend]:
     return {ep.name: ep.load()() for ep in eps}
 
 
-def resolve_backend(selector: str, pyproject: dict[str, Any]) -> Backend | None:
+def resolve_backend(selector: str, pyproject: dict[str, Any]) -> Backend:
     """Resolve the check-sdist ``build-backend`` selector to a Backend.
 
-    ``"none"`` returns None (skip backend logic). ``"auto"`` matches the
-    project's ``build-system.build-backend`` and returns None if unrecognized.
-    Any other value selects a registered backend by name (or declared alias),
-    raising ValueError if unknown.
+    ``"none"`` selects the no-op default backend (no backend-specific logic).
+    ``"auto"`` matches the project's ``build-system.build-backend``, falling
+    back to ``"none"`` if unrecognized. Any other value selects a registered
+    backend by name (or declared alias), raising ValueError if unknown.
     """
-    if selector == "none":
-        return None
-
     backends = load_backends()
 
     if selector == "auto":
@@ -61,7 +58,7 @@ def resolve_backend(selector: str, pyproject: dict[str, Any]) -> Backend | None:
         for backend in backends.values():
             if build_backend in backend.build_backends:
                 return backend
-        return None
+        return backends["none"]
 
     if selector in backends:
         return backends[selector]

--- a/src/check_sdist/backends/none.py
+++ b/src/check_sdist/backends/none.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+__lazy_modules__ = ["typing"]
+
+from typing import Any, ClassVar
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+__all__ = ["NoneBackend"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+class NoneBackend:
+    """The default backend: no backend-specific SDist knowledge.
+
+    Used when no backend is selected or "auto" detection finds no match. It
+    claims no ``build-backend`` strings, so it never wins auto detection; it is
+    only reached as an explicit "none" selection or the fallback.
+    """
+
+    build_backends: ClassVar[tuple[str, ...]] = ()
+
+    def git_only_excludes(  # pylint: disable=unused-argument
+        self, pyproject: dict[str, Any], files: frozenset[str], source_dir: Path
+    ) -> frozenset[str]:
+        return files
+
+    def sdist_only_ignores(  # pylint: disable=unused-argument
+        self, pyproject: dict[str, Any]
+    ) -> Iterator[str]:
+        yield from ()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -5,6 +5,7 @@ import pytest
 from check_sdist._compat import tomllib
 from check_sdist.backends import load_backends, resolve_backend
 from check_sdist.backends.hatchling import HatchlingBackend
+from check_sdist.backends.none import NoneBackend
 from check_sdist.backends.pdm import PdmBackend
 from check_sdist.backends.scikit_build_core import ScikitBuildCoreBackend
 from check_sdist.backends.setuptools import SetuptoolsBackend
@@ -41,7 +42,6 @@ def test_glob_backend_excludes_relative_to_source_dir(
     files = frozenset({"junk.txt", "keep.py"})
 
     backend = resolve_backend("auto", pyproject)
-    assert backend is not None
     result = backend.git_only_excludes(pyproject, files, source_dir)
 
     assert "junk.txt" not in result
@@ -51,6 +51,7 @@ def test_glob_backend_excludes_relative_to_source_dir(
 def test_load_backends_contains_builtins() -> None:
     names = set(load_backends())
     assert {
+        "none",
         "setuptools.build_meta",
         "flit_core.buildapi",
         "hatchling.build",
@@ -74,13 +75,13 @@ def test_resolve_setuptools_aliases(build_backend: str) -> None:
     assert isinstance(resolve_backend("auto", pyproject), SetuptoolsBackend)
 
 
-def test_resolve_none_returns_none() -> None:
-    assert resolve_backend("none", {}) is None
+def test_resolve_none_returns_none_backend() -> None:
+    assert isinstance(resolve_backend("none", {}), NoneBackend)
 
 
-def test_resolve_auto_unknown_returns_none() -> None:
+def test_resolve_auto_unknown_falls_back_to_none() -> None:
     pyproject = {"build-system": {"build-backend": "mystery.backend"}}
-    assert resolve_backend("auto", pyproject) is None
+    assert isinstance(resolve_backend("auto", pyproject), NoneBackend)
 
 
 def test_resolve_unknown_explicit_raises() -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Adds a default `"none"` backend to the plugin system that handles the non-custom behavior, so the backend is no longer threaded through as `Backend | None`.

- **New `NoneBackend`** (`src/check_sdist/backends/none.py`): a null-object backend registered under the `check_sdist.backends` entry-point group. It claims no `build_backends` (so it never wins `auto` detection), returns `files` unchanged from `git_only_excludes`, and yields nothing from `sdist_only_ignores`.
- **`resolve_backend()`** now returns `Backend` instead of `Backend | None`. The `"none"` selector resolves through the normal registered-backend path, and `"auto"` with no match falls back to the `none` backend instead of returning `None`.
- **`compare()`** drops both `if backend is not None:` guards — `sdist_only_ignores(...)` and `git_only_excludes(...)` are now called unconditionally. The backend-agnostic `*.dist-info` ignore is unchanged.
- Updated tests and the `resolve_backend` description in `AGENTS.md`. The README and schema already documented `"none"`, so no changes there.

## Test plan

- `pytest` — all 57 tests pass (including the self-SDist check)
- `prek -a` clean