### PR TITLE
chore: bump to 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To use the [pre-commit](https://pre-commit.com) integration, put this in your
 
 ```yaml
 - repo: https://github.com/henryiii/check-sdist
-  rev: v1.4.0
+  rev: v1.5.0
   hooks:
     - id: check-sdist
       args: [--inject-junk]
@@ -75,7 +75,7 @@ want to require a build dependency listing:
 
 ```yaml
 - repo: https://github.com/henryiii/check-sdist
-  rev: v1.4.0
+  rev: v1.5.0
   hooks:
     - id: check-sdist-isolated
       args: [--inject-junk]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "check-sdist"
-version = "1.4.0"
+version = "1.5.0"
 authors = [
   { name = "Henry Schreiner", email = "henryschreineriii@gmail.com" },
 ]

--- a/src/check_sdist/__init__.py
+++ b/src/check_sdist/__init__.py
@@ -6,6 +6,6 @@ check-sdist: Check the contents of an SDist vs. git
 
 from __future__ import annotations
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
**Features**
- Pluggable per-backend sdist structure via entry points, letting backends define their own expected layout (#169)
- Added a `"none"` default backend to the plugin system (#172)

**Fixes**
- Honor `--no-isolation` when building with uv (#165)
- Glob backend excludes are now relative to `source_dir` instead of the current working directory (#166)
- Corrected the `pdm-backend` `build-backend` value in the schema (#162)
- Inject junk files for the full duration of `compare()` (#161)

**Docs**
- Documented the plugin system and filled in README gaps (#171)
- Added `AGENTS.md`; ignore the local `CLAUDE.md` symlink (#170)

**Tests / CI / Chore**
- Added Python 3.15 to classifiers and CI; made imports lazy on 3.15 (#160, #152)
- Deflaked `test_self_dir` by running against an isolated copy (#167)
- Added a minimum-version test job to the noxfile (#156)
- Bumped `setup-uv` to the maintained tag scheme (#155, #157), `codecov-action` (#153), and pre-commit hooks (#154, #158, #159)
- Minor cleanups from code review (#164)
