### PR TITLE
feat: add uv build backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ following backends ship with check-sdist:
 - `pdm.backend` (pdm-backend)
 - `poetry.core.masonry.api` (poetry-core)
 - `maturin` (maturin)
+- `uv_build` (uv)
 
 You can add support for another backend (or override a built-in one) by shipping
 a small class and registering it under that group. Once installed, `auto`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ check-sdist = "check_sdist.schema:get_schema"
 "pdm.backend" = "check_sdist.backends.pdm:PdmBackend"
 "poetry.core.masonry.api" = "check_sdist.backends.poetry:PoetryBackend"
 "maturin" = "check_sdist.backends.maturin:MaturinBackend"
+"uv_build" = "check_sdist.backends.uv:UvBackend"
 
 [dependency-groups]
 test = [

--- a/src/check_sdist/backends/uv.py
+++ b/src/check_sdist/backends/uv.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+__lazy_modules__ = ["typing"]
+
+from typing import Any, ClassVar
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+__all__ = ["UvBackend"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+class UvBackend:
+    """SDist knowledge for the uv build backend."""
+
+    build_backends: ClassVar[tuple[str, ...]] = ("uv_build",)
+
+    def git_only_excludes(  # pylint: disable=unused-argument
+        self, pyproject: dict[str, Any], files: frozenset[str], source_dir: Path
+    ) -> frozenset[str]:
+        return files
+
+    def sdist_only_ignores(  # pylint: disable=unused-argument
+        self, pyproject: dict[str, Any]
+    ) -> Iterator[str]:
+        # uv keeps a copy of the unmodified pyproject.toml in the SDist.
+        yield "pyproject.toml.orig"

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -9,6 +9,7 @@ from check_sdist.backends.none import NoneBackend
 from check_sdist.backends.pdm import PdmBackend
 from check_sdist.backends.scikit_build_core import ScikitBuildCoreBackend
 from check_sdist.backends.setuptools import SetuptoolsBackend
+from check_sdist.backends.uv import UvBackend
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -59,6 +60,7 @@ def test_load_backends_contains_builtins() -> None:
         "pdm.backend",
         "poetry.core.masonry.api",
         "maturin",
+        "uv_build",
     } <= names
 
 
@@ -122,6 +124,18 @@ def test_pdm_version_write_to() -> None:
     )
     ignore = set(PdmBackend().sdist_only_ignores(pyproject))
     assert "foo/_version.py" in ignore
+
+
+def test_uv_pyproject_orig() -> None:
+    pyproject = tomllib.loads(
+        """
+        [build-system]
+        build-backend = "uv_build"
+        """
+    )
+    backend = resolve_backend("auto", pyproject)
+    assert isinstance(backend, UvBackend)
+    assert "pyproject.toml.orig" in set(backend.sdist_only_ignores(pyproject))
 
 
 def test_scikit_build_generate_paths() -> None:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -126,7 +126,7 @@ def test_pdm_version_write_to() -> None:
     assert "foo/_version.py" in ignore
 
 
-def test_uv_pyproject_orig() -> None:
+def test_uv_pyproject_orig(tmp_path: Path) -> None:
     pyproject = tomllib.loads(
         """
         [build-system]
@@ -136,6 +136,9 @@ def test_uv_pyproject_orig() -> None:
     backend = resolve_backend("auto", pyproject)
     assert isinstance(backend, UvBackend)
     assert "pyproject.toml.orig" in set(backend.sdist_only_ignores(pyproject))
+
+    files = frozenset({"keep.py"})
+    assert backend.git_only_excludes(pyproject, files, tmp_path) == files
 
 
 def test_scikit_build_generate_paths() -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Add a built-in backend plugin for `uv_build`. It ignores `pyproject.toml.orig`, the copy of the unmodified `pyproject.toml` that the uv build backend puts in SDists.

Possible followup: handle `[tool.uv.build-backend] source-exclude` for git-only files. uv uses globset patterns, which do not map cleanly onto the existing `glob_filter` helper, so it needs more thought.