### PR TITLE
feat: support uv build backend source-exclude

### DIFF
--- a/src/check_sdist/backends/uv.py
+++ b/src/check_sdist/backends/uv.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-__lazy_modules__ = ["typing"]
+__lazy_modules__ = [f"{__spec__.parent}._base", "typing"]
 
 from typing import Any, ClassVar
+
+from ._base import pathspec_filter
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -24,7 +26,15 @@ class UvBackend:
     def git_only_excludes(  # pylint: disable=unused-argument
         self, pyproject: dict[str, Any], files: frozenset[str], source_dir: Path
     ) -> frozenset[str]:
-        return files
+        settings = pyproject.get("tool", {}).get("uv", {}).get("build-backend", {})
+        excludes = list(settings.get("source-exclude", []))
+        if settings.get("default-excludes", True):
+            excludes += ["__pycache__", "*.pyc", "*.pyo"]
+        # uv excludes are unanchored unless prefixed with "/"; valid uv globs
+        # can't contain gitignore's "!"/"#" specials, so the translation to
+        # gitignore patterns is exact.
+        patterns = [p if p.startswith("/") else f"**/{p}" for p in excludes]
+        return pathspec_filter(patterns, files)
 
     def sdist_only_ignores(  # pylint: disable=unused-argument
         self, pyproject: dict[str, Any]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -141,6 +141,56 @@ def test_uv_pyproject_orig(tmp_path: Path) -> None:
     assert backend.git_only_excludes(pyproject, files, tmp_path) == files
 
 
+def test_uv_source_exclude(tmp_path: Path) -> None:
+    pyproject = tomllib.loads(
+        """
+        [build-system]
+        build-backend = "uv_build"
+
+        [tool.uv.build-backend]
+        source-exclude = ["*.snap", "docs/build", "/dist"]
+        """
+    )
+    files = frozenset(
+        {
+            "keep.py",
+            "a.snap",
+            "nested/b.snap",
+            "docs/build/index.html",
+            "sub/docs/build/index.html",
+            "dist/pkg.tar.gz",
+            "sub/dist/pkg.tar.gz",
+            "snap/not-matched.py",
+        }
+    )
+    result = UvBackend().git_only_excludes(pyproject, files, tmp_path)
+    # Excludes are unanchored unless prefixed with "/", and a matching
+    # directory excludes its whole subtree.
+    assert result == frozenset(
+        {"keep.py", "sub/dist/pkg.tar.gz", "snap/not-matched.py"}
+    )
+
+
+def test_uv_default_excludes(tmp_path: Path) -> None:
+    pyproject = tomllib.loads(
+        """
+        [build-system]
+        build-backend = "uv_build"
+        """
+    )
+    files = frozenset({"keep.py", "a.pyc", "sub/__pycache__/b.pyc", "c.pyo"})
+    result = UvBackend().git_only_excludes(pyproject, files, tmp_path)
+    assert result == frozenset({"keep.py"})
+
+    no_defaults = tomllib.loads(
+        """
+        [tool.uv.build-backend]
+        default-excludes = false
+        """
+    )
+    assert UvBackend().git_only_excludes(no_defaults, files, tmp_path) == files
+
+
 def test_scikit_build_generate_paths() -> None:
     pyproject = tomllib.loads(
         """


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up to #178. The uv backend plugin now reads `[tool.uv.build-backend] source-exclude` and applies uv's default excludes (`__pycache__`, `*.pyc`, `*.pyo`), honoring `default-excludes = false`.

The #178 note said uv's globset patterns do not map onto `glob_filter` — but they map exactly onto the gitignore-style `pathspec_filter`. Per uv's `build_exclude_matcher`: globset uses `literal_separator(true)` (same `*`/`**` semantics as gitignore), excludes are unanchored unless prefixed with `/` (reproduced by prepending `**/`), a matched directory excludes its subtree, and uv's reduced PEP 639 glob language rejects `!` and `#`, so gitignore's negation and comment cases can never fire.

Include-side semantics (`source-include`, module-only default includes) are intentionally not modeled — that would accept sdists missing most of the repo.