### PR TITLE
ci: wait for all coverage uploads before notifying

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,1 +1,7 @@
 comment: false
+
+codecov:
+  notify:
+    # Number of uploads from the `checks` matrix in ci.yml
+    after_n_builds: 8
+    wait_for_ci: true


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Codecov now holds its notification until every upload arrives. `after_n_builds: 8` matches the `checks` matrix in `ci.yml` (2 Pythons x 3 OS plus the 2 `include` entries), so the status no longer reports on partial coverage. `wait_for_ci: true` is the default, but it is now explicit.

The count must change if the matrix changes.