### PR TITLE
chore: bump to 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To use the [pre-commit](https://pre-commit.com) integration, put this in your
 
 ```yaml
 - repo: https://github.com/henryiii/check-sdist
-  rev: v1.5.0
+  rev: v1.6.0
   hooks:
     - id: check-sdist
       args: [--inject-junk]
@@ -75,7 +75,7 @@ want to require a build dependency listing:
 
 ```yaml
 - repo: https://github.com/henryiii/check-sdist
-  rev: v1.5.0
+  rev: v1.6.0
   hooks:
     - id: check-sdist-isolated
       args: [--inject-junk]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "check-sdist"
-version = "1.5.0"
+version = "1.6.0"
 authors = [
   { name = "Henry Schreiner", email = "henryschreineriii@gmail.com" },
 ]

--- a/src/check_sdist/__init__.py
+++ b/src/check_sdist/__init__.py
@@ -6,6 +6,6 @@ check-sdist: Check the contents of an SDist vs. git
 
 from __future__ import annotations
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Bump the version to 1.6.0 for release. New since v1.5.0: uv build backend support (#178) and its `source-exclude` handling (#180).